### PR TITLE
Remove O_NONBLOCK from fds passed through spawn

### DIFF
--- a/ext/posix-spawn.c
+++ b/ext/posix-spawn.c
@@ -149,8 +149,8 @@ posixspawn_file_actions_adddup2(VALUE key, VALUE val, posix_spawn_file_actions_t
 	if (fd < 0)
 		return ST_CONTINUE;
 
-	fcntl(fd, F_SETFD, fcntl(fd, F_GETFD) & ~FD_CLOEXEC);
-	fcntl(newfd, F_SETFD, fcntl(newfd, F_GETFD) & ~FD_CLOEXEC);
+	fcntl(fd, F_SETFD, fcntl(fd, F_GETFD) & ~FD_CLOEXEC & ~O_NONBLOCK);
+	fcntl(newfd, F_SETFD, fcntl(newfd, F_GETFD) & ~FD_CLOEXEC & ~O_NONBLOCK);
 	posix_spawn_file_actions_adddup2(fops, fd, newfd);
 	return ST_DELETE;
 }

--- a/lib/posix/spawn/version.rb
+++ b/lib/posix/spawn/version.rb
@@ -1,5 +1,5 @@
 module POSIX
   module Spawn
-    VERSION = '0.3.15'
+    VERSION = '0.3.16'
   end
 end


### PR DESCRIPTION
### Overview
This is copy of this [commit](https://github.com/jhawthorn/posix-spawn/commit/529e2147f6e900507efea2559562bd262d816ec3) authored by @jhawthorn and @HParker

We did a fork of repo to be sure that we're using code of original gem with this commit changed only.

### Original commit description 

On Ruby 3.0, IO.pipe and others return nonblocking pipes. Somewhere
inside Ruby's Process.spawn these are moved back to blocking (at least
for stdin, stderr, stdout).

Previously this caused problems with many programs not expecting a
nonblocking pipe, particularly on stdout with large outputs.

This commit removes O_NONBLOCK from any fds whick were being added to
process spawn.

Co-authored-by: Adam Hess <HParker@github.com>

